### PR TITLE
Add symbolic link storage

### DIFF
--- a/flask_collect/storage/link.py
+++ b/flask_collect/storage/link.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Flask-Collect.
+# Copyright (C) 2014 CERN.
+#
+# Flask-Collect is free software; you can redistribute it and/or modify it
+# under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""
+Symbolic link storage for development mode.
+
+It creates symbolic links to the real files so any changes to them will be
+reflected.
+"""
+
+import os
+from .base import BaseStorage
+
+
+class Storage(BaseStorage):
+
+    """Storage that creates symlinks to the resources."""
+
+    def run(self):
+        """Collect static from blueprints.
+
+        Create the directory tree but will symlink all the files.
+        """
+        self.log("Collect static from blueprints")
+        skipped, total = 0, 0
+        for bp, f, o in self:
+            destination = os.path.join(self.collect.static_root, o)
+            destination_dir = os.path.dirname(destination)
+            if not os.path.exists(destination_dir):
+                os.makedirs(destination_dir)
+
+            if not os.path.exists(destination):
+                # the path is a link, but points to invalid location
+                if os.path.islink(destination):
+                    os.remove(destination)
+                os.symlink(f, destination)
+                self.log("{0}:{1} symbolink link created".format(bp.name, o))
+            else:
+                skipped += 1
+            total += 1
+        self.log("{0} of {1} files already present".format(skipped, total))
+        self.log("Done collecting.")


### PR DESCRIPTION
- Adds a symbolic link storage for developers. To enable it, put this
  to your config: COLLECT_STORAGE = u"flask.ext.collect.storage.link"
  then run your `collect` script to create all the links from the
  static folders to the intance folder.
- NOTE only files are symlinked, not folders!

Signed-off-by: Yoan Blanc yoan.blanc@cern.ch
Co-authored-by: Kamil Neczaj kamil.neczaj@cern.ch
Reviewed-by: Jiri Kuncar jiri.kuncar@cern.ch
## 

cc original authors @greut and @kneczaj
