### PR TITLE
Remove file if it already exists before copying

### DIFF
--- a/flask_collect/storage/file.py
+++ b/flask_collect/storage/file.py
@@ -10,7 +10,7 @@
 
 """Copy files from all static folders to root folder."""
 
-from os import path as op, makedirs
+from os import path as op, makedirs, remove
 from shutil import copy
 
 from .base import BaseStorage
@@ -33,6 +33,8 @@ class Storage(BaseStorage):
                 self.log("{0} already copied".format(destination))
             elif not op.exists(destination) or \
                     op.getmtime(destination) < op.getmtime(f):
+                if op.exists(destination):
+                    remove(destination)
                 copy(f, destination)
                 self.log(
                     "Copied: [%s] '%s'" % (


### PR DESCRIPTION
The shutil.copy command will not overwrite files that are read-only which could (should) be the case when deploying files to a webserver, by removing the file if it already exists it will allow the file to be properly replaced with the subsequent copy command.

This is how Django's collectstatic command works (see: https://github.com/django/django/blob/master/django/contrib/staticfiles/management/commands/collectstatic.py#L306) which it appears this app is roughly modeled after.