### PR TITLE
Use when app is created via factory function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Flask-Collect settings (default values): ::
     COLLECT_STATIC_ROOT = <APP.ROOT_PATH>/static
     COLLECT_STORAGE = 'flask_collect.storage.file'
 
-Initialize Flask-Collect extenstion: ::
+Initialize Flask-Collect extension: ::
 
     from flask_collect import Collect
 
@@ -93,6 +93,31 @@ If you use Flask-Script_, activate Flask-Collect commands: ::
     collect = Collect()
     collect.init_app(app)
     collect.init_script(manager)
+
+If you configure Flask via a factory function::
+
+    from flask_collect import Collect
+
+    ...
+
+    def create_app():
+        app = Flask()
+        ...
+        collect = Collect()
+        collect.init_app(app)
+
+        return app
+
+then you can do::
+
+    from flask_collect import CollectAssets
+    from myapp import create_app
+
+    ...
+    manager = Manager(create_app)
+    ...
+
+    manager.add_command('collect', CollectAssets())
 
 
 .. _usage:

--- a/flask_collect/__init__.py
+++ b/flask_collect/__init__.py
@@ -7,7 +7,7 @@ help you collect them in one command. It checks application and blueprints for
 static files and copy them to specific folder (saves related paths).
 """
 
-from .collect import Collect  # noqa
+from .collect import Collect, CollectAssets  # noqa
 
 __author__ = "Kirill Klenov <horneds@gmail.com>"
 __license__ = "BSD"

--- a/flask_collect/collect.py
+++ b/flask_collect/collect.py
@@ -2,6 +2,7 @@
 
 """Define *Flask* extension."""
 
+import flask_script as script
 from flask._compat import string_types
 from werkzeug.utils import import_string
 from os import path as op
@@ -105,3 +106,16 @@ class Collect(object):
         cls = getattr(mod, 'Storage')
         storage = cls(self, verbose=verbose)
         return storage.run()
+
+
+class CollectAssets(script.Command):
+    """Collect assets when app is supplied to Manager as a factory function."""
+    option_list = (
+        script.Option('--verbose', '-v', dest='verbose', default=False, action='store_true'),
+    )
+
+    def run(self, verbose=False):
+        """Runs Collect.collect using the configured current app."""
+        from flask import current_app
+        configured_collect = current_app.extensions['collect']
+        configured_collect.collect(verbose=verbose)


### PR DESCRIPTION
I'm using a factory function to create my Flask app so I needed a way to register Flask-Collect with the FlaskScript Manager before the app was configured. I copied this approach from [Flask-Assets](https://github.com/miracle2k/flask-assets/blob/master/src/flask_assets.py#L412)