### PR TITLE
Update README removing "remove" option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,11 +102,11 @@ Use Flask-Collect
 
 From any python script: ::
 
-    collect.collect(remove=True, verbose=True)
+    collect.collect(verbose=True)
 
 with Flask-Script_:
 
-    $ ./manage.py collect --remove
+    $ ./manage.py collect
 
 
 .. _bugtracker:


### PR DESCRIPTION
It looks like ``remove`` is no longer an option to ``collect``